### PR TITLE
Improved theme switching.

### DIFF
--- a/circadian.el
+++ b/circadian.el
@@ -68,7 +68,7 @@
 
 (defun circadian-enable-theme (theme)
   "Clear previous `custom-enabled-themes' and load THEME."
-  (setq custom-enabled-themes '())
+  (mapc 'disable-theme custom-enabled-themes)
   (load-theme theme t))
 
 (defun circadian-mapcar (entry)


### PR DESCRIPTION
Referring to issue #5 I found a first solution for me. 

Instead of simply deleting the content of {{custom-enabled-themes}} the patch disables all themes in {{custom-enabled-themes}}. It would even be better if only those themes were disabled that are used in {{circadian-themes}} not affecting themes like the smart-modeline themes.