### PR TITLE
V0.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,5 @@ install:
 script:
   # Run your tests
   - cask exec ert-runner
+  # Byte-compile
+  - emacs -Q -batch -f batch-byte-compile circadian.el

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <p align="center">
 <img src="https://melpa.org/packages/circadian-badge.svg" alt="MELPA"/>
 <a href="https://travis-ci.org/guidoschmidt/circadian.el" target="_blank">
-<img src="https://travis-ci.org/guidoschmidt/circadian.el.svg?branch=master" alt="https://travis-ci.org/guidoschmidt/circadian.el"/>
+<img src="https://travis-ci.org/guidoschmidt/circadian.el.svg?branch=v0.2.3"
+     alt="https://travis-ci.org/guidoschmidt/circadian.el"/>
 </a>
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <p align="center">
 <img src="https://melpa.org/packages/circadian-badge.svg" alt="MELPA"/>
+<a href="https://travis-ci.org/guidoschmidt/circadian.el" target="_blank">
 <img src="https://travis-ci.org/guidoschmidt/circadian.el.svg?branch=master" alt="https://travis-ci.org/guidoschmidt/circadian.el"/>
+</a>
 <br>
 <br>
 <br>

--- a/circadian.el
+++ b/circadian.el
@@ -5,7 +5,7 @@
 ;; Author: Guido Schmidt
 ;; Maintainer: Guido Schmidt <guido.schmidt.2912@gmail.com>
 ;; URL: https://github.com/GuidoSchmidt/circadian
-;; Version: 0.2.2
+;; Version: 0.2.3
 ;; Keywords: circadian, themes
 ;; Package-Requires: ((emacs "24.4"))
 
@@ -42,6 +42,8 @@
 ;; - Prefixed cl function like `cl-first', `cl-remove-if'
 ;; - `mapcar' -> `mapc'
 ;; - Swapped argument order for `circadian-filter-inactivate-themes'
+;; - Bugfix: load the last theme from `circadian-themes', when the first
+;;   time slot lies in the future
 ;;
 ;; 0.2.2
 ;; - Added testing (+ configuration for travis CI)
@@ -126,7 +128,9 @@
                                 (circadian-now-time-string))))))
     (let ((time (cl-first entry)))
       (let ((theme (cdr (assoc time circadian-themes))))
-        (load-theme theme t)))))
+        (if (equal theme nil)
+            (circadian-enable-theme (cdr (cl-first (last circadian-themes))))
+          (circadian-enable-theme theme))))))
 
 ;;;###autoload
 (defun circadian-setup ()

--- a/circadian.el
+++ b/circadian.el
@@ -36,7 +36,13 @@
 ;;   (circadian-setup))
 
 ;;; Change Log:
-
+;; 0.2.3
+;; - Use -*- lexical-binding: t -*-
+;; - Requiring cl-lib
+;; - Prefixed cl function like `cl-first', `cl-remove-if'
+;; - `mapcar' -> `mapc'
+;; - Swapped argument order for `circadian-filter-inactivate-themes'
+;;
 ;; 0.2.2
 ;; - Added testing (+ configuration for travis CI)
 ;; - Changed arguments of `circadian-filter-inactivate-themes' to accept
@@ -75,7 +81,7 @@
 
 (defun circadian-mapcar (entry)
   "Map over `circadian-themes' to run a timer for each ENTRY."
-  (let ((time (first entry)))
+  (let ((time (cl-first entry)))
     (let ((theme (cdr (assoc time circadian-themes)))
           (repeat-after 86400))
       (run-at-time time repeat-after 'circadian-enable-theme theme))))
@@ -87,7 +93,7 @@
 
 (defun circadian-now-time-string ()
   "Get the current time as string in the format 'HH:MM'."
-  (let ((only-time (split-string (fourth (split-string (current-time-string))) ":")))
+  (let ((only-time (split-string (cl-fourth (split-string (current-time-string))) ":")))
     (circadian-time-string-from-list (butlast only-time 1))))
 
 (defun circadian-compare-hours (hour-a hour-b)
@@ -102,28 +108,30 @@
   "Compare to time strings TIME-A and TIME-B by hour and minutes."
   (let ((parsed-time-a (parse-time-string time-a))
         (parsed-time-b (parse-time-string time-b)))
-    (and (circadian-compare-hours (third parsed-time-b) (third parsed-time-a))
-         (circadian-compare-minutes (second parsed-time-b) (second parsed-time-a)))))
+    (and (circadian-compare-hours (cl-third parsed-time-b) (cl-third parsed-time-a))
+         (circadian-compare-minutes (cl-second parsed-time-b) (cl-second parsed-time-a)))))
 
-(defun circadian-filter-inactivate-themes (now-time theme-list)
-  "Find themes form THEME-LIST that need activation due to time is before now."
-  (remove-if (lambda (entry)
-               (let ((theme-time (first entry)))
-                 (not (circadian-compare-time-strings theme-time now-time))))
-             theme-list))
+(defun circadian-filter-inactivate-themes (theme-list now-time)
+  "Filter THEME-LIST to consist of themes that are due NOW-TIME."
+  (cl-remove-if (lambda (entry)
+                  (let ((theme-time (cl-first entry)))
+                    (not (circadian-compare-time-strings theme-time now-time))))
+                theme-list))
 
 (defun circadian-activate-latest-theme ()
   "Check which themes are overdue to be activated and load the last.
 `circadian-themes' is expected to be sorted by time for now."
-  (let ((entry (first (last (circadian-filter-inactivate-themes (circadian-now-time-string) circadian-themes)))))
-    (let ((time (first entry)))
+  (let ((entry (cl-first (last (circadian-filter-inactivate-themes
+                                circadian-themes
+                                (circadian-now-time-string))))))
+    (let ((time (cl-first entry)))
       (let ((theme (cdr (assoc time circadian-themes))))
         (load-theme theme t)))))
 
 ;;;###autoload
 (defun circadian-setup ()
   "Setup circadian based on `circadian-themes'."
-  (mapcar 'circadian-mapcar circadian-themes)
+  (mapc 'circadian-mapcar circadian-themes)
   (circadian-activate-latest-theme))
 
 (provide 'circadian)

--- a/circadian.el
+++ b/circadian.el
@@ -1,4 +1,4 @@
-;;; circadian.el --- Theme-switching based on daytime
+;;; circadian.el --- Theme-switching based on daytime -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2017 Guido Schmidt
 
@@ -60,6 +60,8 @@
 ;; - Themes included: hemera-theme, nyx-theme
 
 ;;; Code:
+(require 'cl-lib)
+
 (defcustom circadian-themes '(("7:30" . leuven)
                               ("19:30" . wombat))
   "List of themes mapped to the time they should be loaded."

--- a/test/circadian.el-test.el
+++ b/test/circadian.el-test.el
@@ -29,12 +29,20 @@
                            ("21:00" . wombat)
                            ("23:00" . leuven)))
   (let ((time-now "4:10"))
-    (should (equal 0 (length (circadian-filter-inactivate-themes time-now circadian-themes)))))
+    (should (equal 0 (length (circadian-filter-inactivate-themes
+                              circadian-themes
+                              time-now)))))
   (let ((time-now "5:03"))
-    (should (equal 1 (length (circadian-filter-inactivate-themes time-now circadian-themes)))))
+    (should (equal 1 (length (circadian-filter-inactivate-themes
+                              circadian-themes
+                              time-now)))))
   (let ((time-now "7:20"))
-    (should (equal 2 (length (circadian-filter-inactivate-themes time-now circadian-themes)))))
+    (should (equal 2 (length (circadian-filter-inactivate-themes
+                              circadian-themes
+                              time-now)))))
   (let ((time-now "11:52"))
-    (should (equal 4 (length (circadian-filter-inactivate-themes time-now circadian-themes))))))
+    (should (equal 4 (length (circadian-filter-inactivate-themes
+                              circadian-themes
+                              time-now))))))
 
 ;;; circadian.el-test.el ends here


### PR DESCRIPTION
- Use `-*- lexical-binding: t -*-`
- Requiring `cl-lib`
- Prefixed cl function like `cl-first`, `cl-remove-if`
- `mapcar` changed to `mapc`
- Swapped argument order for `circadian-filter-inactivate-themes`
- Bugfix: load the last theme from `circadian-themes`, when the first time slot lies in the future