### PR TITLE
Use `solar-sunrise-sunset` to avoid dealing with strings.

### DIFF
--- a/test/circadian.el-test.el
+++ b/test/circadian.el-test.el
@@ -24,23 +24,23 @@
                            ("19:54" . adwaita)
                            ("21:12" . wombat)
                            ("23:59" . adwaita)))
-  (let ((time-now "4:10"))
+  (let ((time-now '(4 10)))
     (should (equal 0 (length (circadian-filter-inactivate-themes
                               circadian-themes
                               time-now)))))
-  (let ((time-now "5:03"))
+  (let ((time-now '(5 03)))
     (should (equal 1 (length (circadian-filter-inactivate-themes
                               circadian-themes
                               time-now)))))
-  (let ((time-now "7:20"))
+  (let ((time-now '(7 20)))
     (should (equal 2 (length (circadian-filter-inactivate-themes
                               circadian-themes
                               time-now)))))
-  (let ((time-now "11:52"))
+  (let ((time-now '(11 52)))
     (should (equal 4 (length (circadian-filter-inactivate-themes
                               circadian-themes
                               time-now)))))
-  (let ((time-now "00:14"))
+  (let ((time-now '(00 14)))
     (should (equal 0 (length (circadian-filter-inactivate-themes
                               circadian-themes
                               time-now))))))
@@ -53,11 +53,11 @@
   (setq circadian-themes '(("7:00" . wombat)
                            ("16:00" . tango)))
   (with-mock
-   (stub circadian-now-time-string => "7:21")
+   (stub circadian-now-time => '(7 21))
    (circadian-activate-latest-theme)
    (should (equal 'wombat (cl-first custom-enabled-themes))))
   (with-mock
-   (stub circadian-now-time-string => "17:00")
+   (stub circadian-now-time => '(17 00))
    (circadian-activate-latest-theme)
    (should (equal 'tango (cl-first custom-enabled-themes)))))
 
@@ -74,14 +74,14 @@
    (stub sunrise-sunset => "Sunrise 4:32am (CEST), sunset 4:24pm (CEST) at 8N, 49E (11:52 hrs daylight)")
    (should (equal 1 (length (circadian-filter-inactivate-themes
                              circadian-themes
-                             "14:51"))))
+                             '(14 51)))))
    (with-mock
-    (stub circadian-now-time-string => "14:21")
+    (stub circadian-now-time-string => '(14 21))
     (circadian-activate-latest-theme)
     (should (equal 'wombat (cl-first custom-enabled-themes))))
    (should (equal 2 (length (circadian-filter-inactivate-themes
                              circadian-themes
-                             "23:59"))))))
+                             '(23 59)))))))
 
 
 
@@ -92,9 +92,9 @@
    B should be earlier than A
    => `circadian-a-earlier-b-p' should return `t'."
   (print "-> TEST: time comparisons")
-  (should (equal t (circadian-a-earlier-b-p "7:50" "7:51")))
-  (should (equal nil (circadian-a-earlier-b-p "19:20" "19:19")))
-  (should (equal t (circadian-a-earlier-b-p "20:20" "20:20"))))
+  (should (equal t (circadian-a-earlier-b-p '(7 50) '(7 51))))
+  (should (equal nil (circadian-a-earlier-b-p '(19 20) '(19 19))))
+  (should (equal t (circadian-a-earlier-b-p '(20 20) '(20 20)))))
 
 
 


### PR DESCRIPTION
`solar-sunrise-sunset` returns the same information as `sunrise-sunset`
in data structure instead of string. Using it greatly reduces complexity
of the program.