### PR TITLE
Fix circadian-activate-theme-behavior

### DIFF
--- a/circadian.el
+++ b/circadian.el
@@ -117,8 +117,8 @@
          (past-themes (circadian-filter-inactivate-themes themes now))
          (entry (car (last (or past-themes themes))))
          (theme (cdr entry))
-  (next-entry (or (cadr (member entry themes))
-    (if (circadian-a-earlier-b-p (circadian-now-time) (cl-first entry)) (car themes))))
+         (next-entry (or (cadr (member entry themes))
+                         (if (circadian-a-earlier-b-p (circadian-now-time) (cl-first entry)) (car themes))))
          (next-time (if next-entry
                         (circadian--encode-time
                          (cl-first (cl-first next-entry))

--- a/circadian.el
+++ b/circadian.el
@@ -117,7 +117,8 @@
          (past-themes (circadian-filter-inactivate-themes themes now))
          (entry (car (last (or past-themes themes))))
          (theme (cdr entry))
-         (next-entry (cadr (member entry themes)))
+  (next-entry (or (cadr (member entry themes))
+    (if (circadian-a-earlier-b-p (circadian-now-time) (cl-first entry)) (car themes))))
          (next-time (if next-entry
                         (circadian--encode-time
                          (cl-first (cl-first next-entry))


### PR DESCRIPTION
Schedule to correct time when called earlier than earliest theme, but at the same day. Fix for #25 