### PR TITLE
PERF/circadian.el: use memoized sunset & sunrise times

### DIFF
--- a/circadian.el
+++ b/circadian.el
@@ -166,12 +166,12 @@
          (let  ((sunrise (circadian-sunrise)))
            (if (equal sunrise "not")
                (error "Could not get valid sunset time — check your time zone settings"))
-           (circadian-sunrise)))
+           sunrise))
         ((cl-equalp input :sunset)
          (let ((sunset (circadian-sunset)))
            (if (equal sunset "on")
                (error "Could not get valid sunset time — check your time zone settings"))
-           (circadian-sunset)))
+           sunset))
         ((stringp input) (circadian--string-to-time input))))
 
 ;;;###autoload


### PR DESCRIPTION
Hi. This  a minor performance tweak that speeds up `circadian-themes-parse` by 1x. For some reason we were calling `circadian-sunset` and `circadian-sunrise` twice even though we have the values saved in a let statement.