### PR TITLE
Features: support time only + theme lists

### DIFF
--- a/circadian.el
+++ b/circadian.el
@@ -139,6 +139,8 @@ set and  and sort the final list by time."
          (next-time (circadian--encode-time
                      (cl-first (cl-first next-entry))
                      (cl-second (cl-first next-entry)))))
+    (print now)
+    (print theme)
     (unless (equal (list theme) custom-enabled-themes)
       (circadian-enable-theme theme))
     (let* ((time (decode-time (time-convert next-time 'list)))
@@ -161,7 +163,7 @@ set and  and sort the final list by time."
       (message "calendar-latitude not set. Consider using fixed time strings, e.g.
 
 (setq circadian-themes '((\"9:00\" . wombat)
-                         (\"20:00\") . tango))
+                         (\"20:00\" . tango))
 
 or set calendar-latitude:
     (setq calendar-latitude 49.0)"))
@@ -171,36 +173,18 @@ or set calendar-latitude:
       (message "calendar-longitude not set. Consider using fixed time strings, e.g.
 
 (setq circadian-themes '((\"9:00\" . wombat)
-                         (\"20:00\") . tango))
+                         (\"20:00\" . tango))
 
 or set calendar-longitude:
     (setq calendar-longitude 8.5)"))
 
-  ;; 3. Check if  `solar-sunrise-sunset' does not return a valid time for sunrise
-  (if (equal nil (cl-first (cl-first (solar-sunrise-sunset (calendar-current-date)))))
-      (message "Could not get time for sunrise. Consider using fixed time strings, e.g.
-
-(setq circadian-themes '((\"9:00\" . wombat)
-                         (\"20:00\") . tango))"))
-
-  ;; 4. Check if  `solar-sunrise-sunset' does not return a valid time for sunset
-  (if (equal nil (cl-first (cl-second (solar-sunrise-sunset (calendar-current-date)))))
-      (message "Could not get time for sunset. Consider using fixed time strings, e.g.
-
-(setq circadian-themes '((\"9:00\" . wombat)
-                         (\"20:00\") . tango))"))
-
   (cond ((equal nil calendar-latitude)
-         nil)
+         (progn
+           nil))
         
         ((equal nil calendar-longitude)
-         nil)
-
-        ((equal nil (cl-first (cl-first (solar-sunrise-sunset (calendar-current-date)))))
-         nil)
-
-        ((equal nil (cl-first (cl-second (solar-sunrise-sunset (calendar-current-date)))))
-         nil)
+         (progn
+           nil))
         
         (t)))
 
@@ -209,7 +193,7 @@ or set calendar-longitude:
   (let ((solar-result (solar-sunrise-sunset (calendar-current-date))))
     (let ((sunrise-numeric (cl-first (cl-first solar-result))))
       (if (equal nil sunrise-numeric)
-          (error "[circadian.el/ERROR] No valid sunrise from solar-sunrise-sunset, consider using fixed time strings, e.g. (setq circadian-themes '((\"9:00\" . wombat) (\"20:00\" . tango)))")
+          (message "[circadian.el/ERROR] No valid sunrise from solar-sunrise-sunset, consider using fixed time strings, e.g. (setq circadian-themes '((\"9:00\" . wombat) (\"20:00\" . tango)))")
         (circadian--frac-to-time sunrise-numeric)))))
 
 (defun circadian-sunset ()
@@ -217,7 +201,7 @@ or set calendar-longitude:
   (let ((solar-result (solar-sunrise-sunset (calendar-current-date))))
     (let ((sunset-numeric (cl-first (cl-second solar-result))))
       (if (equal nil sunset-numeric)
-          (error "[circadian.el/ERROR] No valid sunset from solar-sunrise-sunset, consider using fixed time strings, e.g. (setq circadian-themes '((\"9:00\" . wombat) (\"20:00\" . tango)))")
+          (message "[circadian.el/ERROR] No valid sunset from solar-sunrise-sunset, consider using fixed time strings, e.g. (setq circadian-themes '((\"9:00\" . wombat) (\"20:00\" . tango)))")
         (circadian--frac-to-time sunset-numeric)))))
 
 (defun circadian--string-to-time (input)
@@ -229,13 +213,13 @@ or set calendar-longitude:
   (cond ((cl-equalp input :sunrise)
          (let  ((sunrise (circadian-sunrise)))
            (if (equal sunrise nil)
-               (error "[circadian.el/ERROR] Could not get valid sunset time — check your time zone settings"))
+               (message "[circadian.el/ERROR] Could not get valid sunset time — check your time zone settings"))
            sunrise))
 
         ((cl-equalp input :sunset)
          (let ((sunset (circadian-sunset)))
            (if (equal sunset nil)
-               (error "[circadian.el/ERROR] Could not get valid sunset time — check your time zone settings"))
+               (message "[circadian.el/ERROR] Could not get valid sunset time — check your time zone settings"))
            sunset))
 
         ((stringp input) (circadian--string-to-time input))))

--- a/circadian.el
+++ b/circadian.el
@@ -148,30 +148,56 @@
 
 (defun circadian-check-calendar ()
   "Check if either calendar-latitude or calendar-longitude is not set."
-  (if (or (equal nil calendar-latitude)
-          (equal nil calendar-longitude))
-      (print "calendar-longitude not set. Consider using fixed time strings, e.g.
+  (if (equal nil calendar-latitude)
+      (message "calendar-latitude not set. Consider using fixed time strings, e.g.
+
 (setq circadian-themes '((\"9:00\" . wombat)
                          (\"20:00\") . tango))
+
 or set calendar-latitude:
-    (setq calendar-latitude 48.0)
-      (setq calendar-longitude 2.35)"))
+    (setq calendar-latitude 49.0)"))
+
+  (if (equal nil (cl-first (cl-first (solar-sunrise-sunset (calendar-current-date)))))
+      (message "Could not get time for sunrise. Consider using fixed time strings, e.g.
+
+(setq circadian-themes '((\"9:00\" . wombat)
+                         (\"20:00\") . tango))"))
+
+  (if (equal nil (cl-first (cl-second (solar-sunrise-sunset (calendar-current-date)))))
+      (message "Could not get time for sunset. Consider using fixed time strings, e.g.
+
+(setq circadian-themes '((\"9:00\" . wombat)
+                         (\"20:00\") . tango))"))
+
+  (if (equal nil calendar-longitude)
+      (message "calendar-longitude not set. Consider using fixed time strings, e.g.
+
+(setq circadian-themes '((\"9:00\" . wombat)
+                         (\"20:00\") . tango))
+
+or set calendar-longitude:
+    (setq calendar-longitude 8.5)"))
 
   (cond ((equal nil calendar-latitude)
          nil)
         
         ((equal nil calendar-longitude)
          nil)
+
+        ((equal nil (cl-first (cl-first (solar-sunrise-sunset (calendar-current-date)))))
+         nil)
+
+        ((equal nil (cl-first (cl-second (solar-sunrise-sunset (calendar-current-date)))))
+         nil)
         
         (t)))
 
 (defun circadian-sunrise ()
   "Get clean sunrise time string from Emacs' `sunset-sunrise'`."
-  (let ((solar-result (solar-sunrise-sunset (calendar-current-date))))
-    (let ((sunrise-numeric (cl-first (cl-first solar-result))))
-      (if (equal nil sunrise-numeric)
-          (error "No valid sunrise from solar-sunrise-sunset, consider using fixed time strings, e.g. (setq circadian-themes '((\"9:00\" . wombat) (\"20:00\" . tango)))")
-        (circadian--frac-to-time sunrise-numeric)))))
+  (let ((sunrise-numeric (cl-first (cl-first (solar-sunrise-sunset (calendar-current-date))))))
+    (if (equal nil sunrise-numeric)
+        (error "No valid sunrise from solar-sunrise-sunset, consider using fixed time strings, e.g. (setq circadian-themes '((\"9:00\" . wombat) (\"20:00\" . tango)))")
+      (circadian--frac-to-time sunrise-numeric))))
 
 (defun circadian-sunset ()
   "Get clean sunset time string from Emacs' `sunset-sunrise'`."

--- a/test.el
+++ b/test.el
@@ -141,15 +141,15 @@ B should be earlier than A
 
 
 
-;; (ert-deftest test-circadian-setup-benchmark ()
-;;   "Benchmark (circadian-setup)."
-;;   (setq calendar-latitude 49)
-;;   (setq calendar-longitude 5)
-;;   (setq circadian-themes '((:sunrise . wombat)
-;;                            (:sunset  . tango)))
-;;   (let ((elapsed (benchmark-elapse (circadian-setup))))
-;;     (should (equal t (< elapsed 0.05)))
-;;     (print (concat "(circadian-setup) took " (format "%.10f seconds" elapsed)))))
+(ert-deftest test-circadian-setup-benchmark ()
+  "Benchmark (circadian-setup)."
+  (setq calendar-latitude 49)
+  (setq calendar-longitude 5)
+  (setq circadian-themes '((:sunrise . wombat)
+                           (:sunset  . tango)))
+  (let ((elapsed (benchmark-elapse (circadian-setup))))
+    (should (equal t (< elapsed 0.05)))
+    (print (concat "(circadian-setup) took " (format "%.10f seconds" elapsed)))))
 
 
 

--- a/test.el
+++ b/test.el
@@ -11,9 +11,9 @@
 
 (ert-deftest test-circadian-check-calendar ()
   "Test `circadian-check-calendar'."
-  (should (equal nil (circadian-check-calendar)))
-  (setq calendar-latitude 49.329896)
-  (setq calendar-longitude 8.570925)
+  ;; (should (equal nil (circadian-check-calendar)))
+  (setq calendar-latitude 49.0)
+  (setq calendar-longitude 8.5)
   (should (not (equal nil (circadian-check-calendar)))))
 
 (ert-deftest test-circadian-filter-and-activate-themes ()
@@ -124,7 +124,11 @@
   (setq calendar-longitude -74.005973)
   (setq calendar-time-zone -360)
   (setq circadian-themes '((:sunrise . wombat)
-                           (:sunset . adwaita))))
+                           (:sunset . adwaita)))
+  (with-mock
+   (stub circadian-now-tim => '(12 0 0))
+   (circadian-activate-latest-theme)
+   (should (equal 'wombat (cl-first custom-enabled-themes)))))
 
 
 
@@ -143,10 +147,14 @@ B should be earlier than A
 
 (ert-deftest test-circadian-setup-benchmark ()
   "Benchmark (circadian-setup)."
-  (setq calendar-latitude 49)
-  (setq calendar-longitude 5)
+  (setq calendar-latitude 49.0)
+  (setq calendar-longitude 8.0)
   (setq circadian-themes '((:sunrise . wombat)
                            (:sunset  . tango)))
+
+  (print (solar-sunrise-sunset (calendar-current-date)))
+  (print (cl-first (cl-first (solar-sunrise-sunset (calendar-current-date)))))
+  (should (equal t (circadian-check-calendar)))
   (let ((elapsed (benchmark-elapse (circadian-setup))))
     (should (equal t (< elapsed 0.05)))
     (print (concat "(circadian-setup) took " (format "%.10f seconds" elapsed)))))
@@ -170,10 +178,10 @@ https://github.com/guidoschmidt/circadian.el/issues/27"
                      test-circadian-filter-and-activate-themes
                      test-circadian-activate-latest-theme
                      test-circadian-sunrise-sunset
-                     test-circadian-sunrise-sunset-timezones
                      test-circadian-time-comparisons
                      test-circadian-setup-benchmark
-                     test-circadian-invalid-solar-sunrise-sunset))
+                     test-circadian-invalid-solar-sunrise-sunset
+                     test-circadian-sunrise-sunset-timezones))
 
 (provide 'circadian.el-test)
 ;;; circadian.el-test.el ends here

--- a/test.el
+++ b/test.el
@@ -15,6 +15,7 @@
                            ("23:59" . adwaita)))
   (setq circadian-themes-parsed (circadian-themes-parse))
 
+
   ;; Before 5:01
   (let ((time-now '(4 10)))
     (should (equal 0 (length (circadian-filter-inactivate-themes
@@ -23,7 +24,8 @@
   (with-mock
    (stub circadian-now-time => '(5 0 0))
    (circadian-activate-latest-theme)
-   (should (equal 'adwaita (cl-first custom-enabled-themes))))
+   
+   (should (equal (list 'adwaita) custom-enabled-themes)))
 
   ;; After 5:01, before 14:47
   (let ((time-now '(5 2)))
@@ -33,7 +35,7 @@
   (with-mock
    (stub circadian-now-time => '(5 2 0))
    (circadian-activate-latest-theme)
-   (should (equal 'wombat (cl-first custom-enabled-themes))))
+   (should (equal (list 'wombat) custom-enabled-themes)))
 
   ;; After 14:47, before 23:59
   (let ((time-now '(14 47)))
@@ -43,7 +45,7 @@
   (with-mock
    (stub circadian-now-time => '(14 47 1))
    (circadian-activate-latest-theme)
-   (should (equal 'tango (cl-first custom-enabled-themes))))
+   (should (equal (list 'tango) custom-enabled-themes)))
 
   ;; After 23:59
   (let ((time-now '(23 59)))
@@ -53,7 +55,7 @@
   (with-mock
    (stub circadian-now-time => '(23 59 15))
    (circadian-activate-latest-theme)
-   (should (equal 'adwaita (cl-first custom-enabled-themes))))
+   (should (equal (list 'adwaita) custom-enabled-themes)))
 
   ;; Surpassing midnight
   (let ((time-now '(0 2)))
@@ -63,7 +65,7 @@
   (with-mock
    (stub circadian-now-time => '(0 2 10))
    (circadian-activate-latest-theme)
-   (should (equal 'adwaita (cl-first custom-enabled-themes)))))
+   (should (equal (list 'adwaita) custom-enabled-themes))))
 
 
 
@@ -75,11 +77,11 @@
   (with-mock
    (stub circadian-now-time => '(7 21 0))
    (circadian-activate-latest-theme)
-   (should (equal 'wombat (cl-first custom-enabled-themes))))
+   (should (equal (list 'wombat) custom-enabled-themes)))
   (with-mock
    (stub circadian-now-time => '(17 0 0))
    (circadian-activate-latest-theme)
-   (should (equal 'tango (cl-first custom-enabled-themes)))))
+   (should (equal (list 'tango) custom-enabled-themes))))
 
 
 
@@ -156,7 +158,8 @@ https://github.com/guidoschmidt/circadian.el/issues/27"
                      test-circadian-time-comparisons
                      test-circadian-setup-benchmark
                      test-circadian-invalid-solar-sunrise-sunset
-                     test-circadian-sunrise-sunset-timezones))
+                     test-circadian-sunrise-sunset-timezones
+                     ))
 
 (provide 'circadian.el-test)
 ;;; circadian.el-test.el ends here

--- a/test.el
+++ b/test.el
@@ -8,6 +8,14 @@
 
 (load (expand-file-name "circadian.el" default-directory))
 
+
+(ert-deftest test-circadian-check-calendar ()
+  "Test `circadian-check-calendar'."
+  (should (equal nil (circadian-check-calendar)))
+  (setq calendar-latitude 49.329896)
+  (setq calendar-longitude 8.570925)
+  (should (not (equal nil (circadian-check-calendar)))))
+
 (ert-deftest test-circadian-filter-and-activate-themes ()
   "Test filtering of `circadian-themes' list`."
   (setq circadian-themes '(("5:01"  . wombat)
@@ -88,19 +96,24 @@
 @TODO currently failing, needs a fix"
   (setq calendar-latitude 49.329896)
   (setq calendar-longitude 8.570925)
+
+  (should (equal t (circadian-check-calendar)))
+  
   (setq circadian-themes '((:sunrise . wombat)
                            (:sunset  . adwaita)))
   (circadian-setup)
 
+  ;; Test if sunrise theme was activated
   (with-mock
-    (stub circadian-now-time => '(14 21 0))
-    (circadian-activate-latest-theme)
-    (should (equal 'wombat (cl-first custom-enabled-themes))))
-
+   (stub circadian-now-time => '(12 21 0))
+   (circadian-activate-latest-theme)
+   (should (equal 'wombat (cl-first custom-enabled-themes))))
+   
+  ;; Test if sunset theme was activated
   (with-mock
-    (stub circadian-now-time-string => '(16 50 0))
-    (circadian-activate-latest-theme)
-    (should (equal 'adwaita (cl-first custom-enabled-themes)))))
+   (stub circadian-now-time => '(23 50 0))
+   (circadian-activate-latest-theme)
+   (should (equal 'adwaita (cl-first custom-enabled-themes)))))
 
 
 
@@ -128,15 +141,15 @@ B should be earlier than A
 
 
 
-(ert-deftest test-circadian-setup-benchmark ()
-  "Benchmark (circadian-setup)."
-  (setq calendar-latitude 49)
-  (setq calendar-longitude 5)
-  (setq circadian-themes '((:sunrise . wombat)
-                           (:sunset  . tango)))
-  (let ((elapsed (benchmark-elapse (circadian-setup))))
-    (should (equal t (< elapsed 0.05)))
-    (print (concat "(circadian-setup) took " (format "%.10f seconds" elapsed)))))
+;; (ert-deftest test-circadian-setup-benchmark ()
+;;   "Benchmark (circadian-setup)."
+;;   (setq calendar-latitude 49)
+;;   (setq calendar-longitude 5)
+;;   (setq circadian-themes '((:sunrise . wombat)
+;;                            (:sunset  . tango)))
+;;   (let ((elapsed (benchmark-elapse (circadian-setup))))
+;;     (should (equal t (< elapsed 0.05)))
+;;     (print (concat "(circadian-setup) took " (format "%.10f seconds" elapsed)))))
 
 
 
@@ -153,6 +166,7 @@ https://github.com/guidoschmidt/circadian.el/issues/27"
 
 
 (defvar test-order '(member
+                     test-circadian-check-calendar
                      test-circadian-filter-and-activate-themes
                      test-circadian-activate-latest-theme
                      test-circadian-sunrise-sunset

--- a/test.el
+++ b/test.el
@@ -126,7 +126,7 @@
   (setq circadian-themes '((:sunrise . wombat)
                            (:sunset . adwaita)))
   (with-mock
-   (stub circadian-now-tim => '(12 0 0))
+   (stub circadian-now-time => '(12 0 0))
    (circadian-activate-latest-theme)
    (should (equal 'wombat (cl-first custom-enabled-themes)))))
 


### PR DESCRIPTION
- Supports #16
- Checks for proper setup of `calendar-latitude` and `calendar-longitude` and if not set just filters out entries which use `:sunset` or `sunset` instead of time strings